### PR TITLE
Store _prev as a tuple in sum() and mean()

### DIFF
--- a/leanpass/tensor.py
+++ b/leanpass/tensor.py
@@ -241,7 +241,7 @@ class Tensor:
     def sum(self, axis=None, keepdims=False):
         out_data = self.data.sum(axis=axis, keepdims=keepdims)
         out = Tensor(out_data, requires_grad=self.requires_grad, name="sum")
-        out._prev = {self}
+        out._prev = (self,)
         out._op = "sum"
         out._meta = {"axis": axis, "keepdims": keepdims, "shape": self.data.shape}
 
@@ -260,7 +260,7 @@ class Tensor:
     def mean(self, axis=None, keepdims=False):
         out_data = self.data.mean(axis=axis, keepdims=keepdims)
         out = Tensor(out_data, requires_grad=self.requires_grad, name="mean")
-        out._prev = {self}
+        out._prev = (self,)
         out._op = "mean"
         out._meta = {"axis": axis, "keepdims": keepdims, "shape": self.data.shape}
 

--- a/tests/test_gradcheck.py
+++ b/tests/test_gradcheck.py
@@ -79,3 +79,15 @@ def test_visualize_dot():
     assert dot.startswith("digraph")
     assert "->" in dot
     assert "input" in dot
+
+
+def test_eval_forward_handles_reductions():
+    # sum() and mean() stored their _prev as a set instead of a tuple, so
+    # _eval_forward's `node._prev[0]` indexing raised
+    # "TypeError: 'set' object is not subscriptable" for any graph that reduces
+    # with sum or mean, which is almost every loss.
+    x = Tensor([[1.0, 2.0], [3.0, 4.0]], requires_grad=True)
+    assert np.isclose((x * x).sum()._eval_forward(), 30.0)
+
+    y = Tensor([1.0, 2.0, 3.0], requires_grad=True)
+    assert np.isclose((y * y).mean()._eval_forward(), 14.0 / 3.0)


### PR DESCRIPTION
Fixes #7.

### The bug

Every op builds its `_prev` through `_create_child`, which normalises the argument with `tuple(prev)`. `sum()` and `mean()` skip that helper and assign the set directly:

```python
out._prev = {self}
```

so those two nodes carry a `set` while every other node carries a tuple.

`_eval_forward` pulls operands by index:

```python
elif node._op == "sum":
    values[node] = values[node._prev[0]].sum()
```

Indexing a set raises `TypeError: 'set' object is not subscriptable`, so evaluating any graph that reduces with `sum` or `mean` (which is almost every loss) crashes.

### The fix

Store `(self,)` in both methods so `_prev` is a tuple everywhere:

```python
out._prev = (self,)
```

### Test

Added `test_eval_forward_handles_reductions`, which runs a `sum` graph and a `mean` graph through `_eval_forward` and checks the values (30.0 and 14/3). It raises `TypeError` on `main` and passes with this change. The full `tests/test_gradcheck.py` suite passes locally.

One heads-up while I was in there: `grad_check` has a separate, unrelated problem where it perturbs the reduced output node (`node.data[idx] = ...`) whose data is a scalar, which raises `'numpy.float64' object does not support item assignment`. That is outside the scope of this fix, so I left it alone, but happy to open a follow-up if useful.
