### PR TITLE
Update setup.cfg from `0.1.3` to `0.1.5`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = leanpass
-version = 0.1.3
+version = 0.1.5
 
 [flake8]
 max-line-length = 88


### PR DESCRIPTION
Fix the `setup.cfg` version tracking mistake